### PR TITLE
Basic support for text attributes/colors.

### DIFF
--- a/examples/border.cr
+++ b/examples/border.cr
@@ -1,0 +1,14 @@
+require "../src/crt"
+
+Crt.init
+x = Crt.x
+y = Crt.y
+tlwin = Crt::Window.new(y / 2, x / 2)
+brwin = Crt::Window.new(y / 2, x / 2, y / 2, x / 2)
+tlwin.border
+brwin.border('l', 'l', '-', '-', '+', '+', '+', '+')
+brwin.refresh
+tlwin.refresh
+loop do
+end
+Crt.done

--- a/examples/color.cr
+++ b/examples/color.cr
@@ -1,0 +1,27 @@
+require "../src/crt"
+
+#Startup
+Crt.init
+Crt.start_color
+
+#Set up colors
+red = Crt::ColorPair.new(Crt::Color::Red, Crt::Color::Default)
+blue = Crt::ColorPair.new(Crt::Color::Blue, Crt::Color::Default)
+Crt.init_color(Crt::Color::Magenta, 75, 0 ,130)
+custom = Crt::ColorPair.new(Crt::Color::Magenta, Crt::Color::Default)
+
+#Put stuff on the screen
+win = Crt::Window.new
+win.attribute_on red
+win.print(3, 3, "I'm red!")
+win.attribute_on blue
+win.print(6, 3, "I'm blue!")
+win.attribute_on Crt::Attribute::Reverse
+win.print(9, 3, "I'm a custom color")
+win.refresh
+
+sleep 10.seconds
+win.set_background(Crt::ColorPair.new(Crt::Color::White, Crt::Color::Black))
+win.refresh
+
+Crt.done

--- a/spec/color_spec.cr
+++ b/spec/color_spec.cr
@@ -1,0 +1,22 @@
+require "./spec_helper.cr"
+
+describe Crt do
+	Crt.init
+
+	it ".start_color" do
+		Crt.start_color
+	end
+
+	it "Makes colored window" do
+		win = Crt::Window.new
+		win.clear
+		
+		red = Crt::ColorPair.new(Crt::Color::Red, Crt::Color::Default)
+
+		win.attribute_on red
+		win.puts "I'm red"
+		win.refresh
+	end
+end
+
+	

--- a/src/crt.cr
+++ b/src/crt.cr
@@ -15,6 +15,9 @@ module Crt
     return if @@initialized
 
     LibC.setlocale(LibNcursesw::LC_ALL, "")
+	if(LibNcursesw.has_colors) # This causes the error
+		LibNcursesw.start_color
+	end
     
     @@stdscr = LibNcursesw.initscr
     @@initialized = true

--- a/src/crt.cr
+++ b/src/crt.cr
@@ -2,6 +2,7 @@ require "./libncursesw"
 
 module Crt
   @@initialized = false
+  @@colors_on = false
   
   def self.stdscr : LibNcursesw::WindowPtr
     unless @@initialized
@@ -10,14 +11,10 @@ module Crt
     return @@stdscr.not_nil!
   end
 
-  # TODO: color
   def self.init
     return if @@initialized
 
     LibC.setlocale(LibNcursesw::LC_ALL, "")
-	if(LibNcursesw.has_colors) # This causes the error
-		LibNcursesw.start_color
-	end
     
     @@stdscr = LibNcursesw.initscr
     @@initialized = true
@@ -38,6 +35,21 @@ module Crt
       LibNcursesw.endwin
       @@initialized = false
     end
+  end
+
+  def self.start_color
+	result = LibNcursesw.start_color
+	unless result == -1
+		@@colors_on = true
+		LibNcursesw.use_default_colors
+	end
+  end
+
+  def self.init_color(color : Color, r : Int, g : Int, b : Int)
+		(r * 1000 / 255).clamp(0..1000)
+		(g * 1000 / 255).clamp(0..1000)
+		(b * 1000 / 255).clamp(0..1000)
+		LibNcursesw.init_color(color.value, r, g, b)
   end
 
   # change input mode to `cooked`
@@ -121,6 +133,33 @@ module Crt
     else
       return c.ord
     end
+  end
+  
+  # TODO Figure out how to support 256 colors
+  enum Color
+	  Default = -1
+	  Black = 0
+	  Red = 1
+	  Green = 2
+  	  Yellow = 3
+	  Blue = 4
+	  Magenta = 5
+	  Cyan = 6
+	  White = 7
+  end
+
+  # TODO Make sure these are the same across multiple systems/terminals
+  enum Attribute
+	Normal = 0
+	Altcharset = 4194304
+	Blink = 524288
+	Bold = 2097152
+	Dim = 1048576
+	Invis = 8388608
+	Protect = 16777216
+	Reverse = 262144
+	Standout = 65536
+	Underline = 131072
   end
 end
 

--- a/src/crt/colorpair.cr
+++ b/src/crt/colorpair.cr
@@ -1,0 +1,20 @@
+# coding: utf-8
+# TODO: Add a cleanup method to free up the slot
+module Crt
+	class ColorPair
+		getter slot
+		@@slot_counter = 1_i16
+		@slot : Int16
+		
+		def initialize(foreground : Color, background : Color)
+			Crt.init
+			@slot = @@slot_counter
+			LibNcursesw.init_pair(@slot, foreground, background)
+			@@slot_counter += 1
+		end
+
+		def value
+			return LibNcursesw.color_pair(@slot)
+		end
+	end
+end

--- a/src/crt/window.cr
+++ b/src/crt/window.cr
@@ -16,6 +16,18 @@ module Crt
       LibNcursesw.use_default_colors
     end
 
+	def attribute_on(attr : (ColorPair | Attribute))
+		LibNcursesw.wattron(@winp, attr.value)
+	end
+
+	def attribute_off(attr : (ColorPair | Attribute))
+		LibNcursesw.wattroff(@winp, attr.value)
+	end
+
+	def set_background(pair : ColorPair)
+		LibNcursesw.wbkgd(@winp, pair.value)
+	end
+
     def print(y : Int32, x : Int32, str : String)
       LibNcursesw.mvwaddstr(@winp, y, x, str)
     end

--- a/src/libncursesw.cr
+++ b/src/libncursesw.cr
@@ -28,6 +28,7 @@ lib LibNcursesw
   type WindowPtr = Void*
 
   fun cbreak : Int32
+  fun color_pair = COLOR_PAIR(slot : Int16) : Int32
   fun curs_set(v : Int32) : Int32
   fun echo : Int32
   fun endwin : Int32
@@ -39,6 +40,8 @@ lib LibNcursesw
   fun getstr(str : LibC::Char*) : Int32
   fun halfdelay(v : Int32) : Int32
   fun has_colors : Bool
+  fun init_color(color : Int16, r : Int16, g : Int16, b : Int16)
+  fun init_pair(slot : Int16, foreground : Int16, background : Int16)
   fun initscr : WindowPtr
   fun intrflush(win : WindowPtr, bool : Bool) : Int32
   fun keypad(win : WindowPtr, bool : Bool) : Int32
@@ -55,6 +58,9 @@ lib LibNcursesw
   fun start_color : Int32
   fun use_default_colors : Int32
   fun waddstr(win : WindowPtr, str : LibC::Char*) : Int32
+  fun wattroff(win : WindowPtr, attr : Int32) : Int32
+  fun wattron(win : WindowPtr, attr : Int32) : Int32
+  fun wbkgd(win : WindowPtr, pair : Int32) : Int32
   fun wborder(win : WindowPtr, ls : Int32, rs : Int32, ts : Int32, bs : Int32, tl : Int32, tr : Int32, bl : Int32, br : Int32) : Int32
   fun wclear(win : WindowPtr) : Int32
   fun wmove(win : WindowPtr, y : Int32, x : Int32) : Int32

--- a/src/libncursesw.cr
+++ b/src/libncursesw.cr
@@ -38,6 +38,7 @@ lib LibNcursesw
   fun getnstr(str : LibC::Char*, n : Int32) : Int32
   fun getstr(str : LibC::Char*) : Int32
   fun halfdelay(v : Int32) : Int32
+  fun has_colors : Bool
   fun initscr : WindowPtr
   fun intrflush(win : WindowPtr, bool : Bool) : Int32
   fun keypad(win : WindowPtr, bool : Bool) : Int32


### PR DESCRIPTION
I wanted to make text certain colors, so I did this:

- Added a `start_color` method to Crt. This enables text coloring, it must be called before any colors can be used. I chose not to make it run by default, because it overwrites the terminals default colors, which may be desired.
- Added a `Color` enum to Crt to make selecting colors easy.
- Added the `ColorPair` class. This is an OOP approach to ncurses' `COLOR_PAIR(int)` & `init_pair(short, int, int)` functions.
- Added `init_color` method to Crt. This changes a color's value.
- Added `attribute_on`, `attribute_off` and `attribute_set` methods to window, in order to change text/window colors. All of these methods take a color pair, `attribute_on` and `attribute_off` can also take a member of the `Attribute` enum.
- Added an attribute enum. 
- Finally, added example usage of color methods.