### PR TITLE
Add horizontal and vertical line drawing function.

### DIFF
--- a/src/crt/window.cr
+++ b/src/crt/window.cr
@@ -68,5 +68,13 @@ module Crt
               Crt.chr_to_int_ACS(bl),
               Crt.chr_to_int_ACS(br))
     end
+
+	def mvvline(y : Int32, x : Int32, ch = '│', n = @row)
+		LibNcursesw.mvwvline(@winp, y, x, Crt.chr_to_int_ACS(ch), n)
+	end
+
+	def mvhline(y : Int32, x : Int32, ch = '─', n = @col)
+		LibNcursesw.mvwhline(@winp, y, x, Crt.chr_to_int_ACS(ch), n)
+	end
   end
 end

--- a/src/libncursesw.cr
+++ b/src/libncursesw.cr
@@ -43,6 +43,8 @@ lib LibNcursesw
   fun keypad(win : WindowPtr, bool : Bool) : Int32
   fun mouseinterval(v : Int32) : Int32
   fun mvwaddstr(win : WindowPtr, y : Int32, x : Int32, str : LibC::Char*) : Int32
+  fun mvwhline(win: WindowPtr, y : Int32, x : Int32, ch : Int32, n : Int32)
+  fun mvwvline(win: WindowPtr, y : Int32, x : Int32, ch : Int32, n : Int32)
   fun newwin(rows : Int32, cols : Int32, y : Int32, x : Int32) : WindowPtr
   fun nocbreak : Int32
   fun nodelay(win : WindowPtr, b : Bool) : Int32


### PR DESCRIPTION
`mvhline` and `mvvline` default to the `'─'` and `'│'` respectively.