### PR TITLE
curs_set(TRUE) when initialize window

### DIFF
--- a/src/crt.cr
+++ b/src/crt.cr
@@ -23,14 +23,14 @@ module Crt
     LibNcursesw.nonl
     LibNcursesw.intrflush(stdscr, false)
     LibNcursesw.keypad(stdscr, true)
-    LibNcursesw.curs_set(0)
+    LibNcursesw.curs_set(1)
 
     at_exit { Crt.done }
   end
 
   def self.done
     if @@initialized
-      LibNcursesw.curs_set(1)
+      LibNcursesw.curs_set(0)
       LibNcursesw.endwin
       @@initialized = false
     end


### PR DESCRIPTION
I really don't understand why the cursor will be hidden when initialize the window.
It should be bug?

Thanks!