### PR TITLE
Instance variables for Windows.initialize

### DIFF
--- a/src/crt/window.cr
+++ b/src/crt/window.cr
@@ -3,13 +3,11 @@ module Crt
   class Window
     getter row, col
 
-    def initialize(r = -1, c = -1, y = 0, x = 0)
+    def initialize(@row = -1, @col = -1, y = 0, x = 0)
       Crt.init
-      r = Crt.y if r < 0
-      c = Crt.x if c < 0
-      @winp = LibNcursesw.newwin(r, c, y, x)
-      @row = r
-      @col = c
+      @row = Crt.y if @row < 0
+      @col = Crt.x if @col < 0
+      @winp = LibNcursesw.newwin(@row, @col, y, x)
     end
 
     def use_default_colors


### PR DESCRIPTION
Allows inference of variables which was creating an error in Crystal 0.25.1